### PR TITLE
feat(android+ios): implement CardConfiguration

### DIFF
--- a/android/src/main/java/com/reactnativeadyendropin/ConfigurationParser.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/ConfigurationParser.kt
@@ -61,6 +61,10 @@ class ConfigurationParser(private val clientKey: String, context: ReactApplicati
     return "${this.context.packageName}_${System.currentTimeMillis()}"
   }
 
+  fun getBoolean(config: ReadableMap?, name: String): Boolean {
+    return config !== null && config.hasKey(name) && config.getBoolean(name)
+  }
+
   fun parse(config: ReadableMap): DropInConfiguration {
     val shopperLocale = this.getShopperLocale(config)
     val environment = this.getEnvironment(config)
@@ -70,7 +74,13 @@ class ConfigurationParser(private val clientKey: String, context: ReactApplicati
     val cardConfiguration = CardConfiguration.Builder(shopperLocale, environment, this.clientKey)
       .setShopperReference(shopperReference)
       .setSupportedCardTypes(CardType.MASTERCARD, CardType.VISA)
-      .build()
+
+    if (config.getMap("card") != null) {
+      cardConfiguration
+        .setHolderNameRequired(getBoolean(config.getMap("card"), "showsHolderNameField"))
+        .setShowStorePaymentField(getBoolean(config.getMap("card"), "showsStorePaymentMethodField"))
+        .setHideCvc(!getBoolean(config.getMap("card"), "showsSecurityCodeField"))
+    }
 
     val builder = DropInConfiguration.Builder(
       this.context,
@@ -80,7 +90,7 @@ class ConfigurationParser(private val clientKey: String, context: ReactApplicati
       .setShopperLocale(shopperLocale)
       .setEnvironment(environment)
       .setAmount(amount)
-      .addCardConfiguration(cardConfiguration)
+      .addCardConfiguration(cardConfiguration.build())
 
     return builder.build()
   }

--- a/ios/ConfigurationParser.swift
+++ b/ios/ConfigurationParser.swift
@@ -50,6 +50,12 @@ struct ConfigurationParser {
             }
         }
         
+        if let cardConfig = config.value(forKey: "card") as? NSDictionary {
+            nextConfig.card.showsHolderNameField = cardConfig.value(forKey: "showsHolderNameField") as! Bool
+            nextConfig.card.showsStorePaymentMethodField = cardConfig.value(forKey: "showsStorePaymentMethodField") as! Bool
+            nextConfig.card.showsSecurityCodeField = cardConfig.value(forKey: "showsSecurityCodeField") as! Bool
+        }
+        
         return nextConfig
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,9 @@ export type Amount = {
 };
 
 export type CardConfiguration = {
-  /** @todo NOT IMPLEMENTED */
-  showsHolderNameField?: boolean;
-  /** @todo NOT IMPLEMENTED */
-  showsStorePaymentMethodField?: boolean;
-  /** @todo NOT IMPLEMENTED */
-  showsSecurityCodeField?: boolean;
+  showsHolderNameField: boolean;
+  showsStorePaymentMethodField: boolean;
+  showsSecurityCodeField: boolean;
 };
 
 export type ApplePayConfiguration = {
@@ -31,7 +28,6 @@ export type DropInConfiguration = {
   environment: 'test' | 'live';
   countryCode: string;
   amount: Amount;
-  /** @todo NOT IMPLEMENTED */
   card?: CardConfiguration;
   applePay?: ApplePayConfiguration;
   returnUrl?: string;


### PR DESCRIPTION
This makes it possible to pass `CardConfiguration` from TypeScript, via
`AdyenDropIn.setDropInConfig()`.