### PR TITLE
feat(android+ios): implement payment callbacks

### DIFF
--- a/android/src/main/java/com/reactnativeadyendropin/AdyenDropInModule.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/AdyenDropInModule.kt
@@ -10,8 +10,10 @@ import com.adyen.checkout.core.model.getStringOrNull
 import com.adyen.checkout.dropin.DropIn
 import com.adyen.checkout.dropin.DropInConfiguration
 import com.adyen.checkout.dropin.DropInResult
+import com.adyen.checkout.dropin.service.DropInServiceResult
 import com.facebook.react.bridge.*
 import com.reactnativeadyendropin.data.storage.MemoryStorage
+import com.reactnativeadyendropin.service.AdyenDropInService
 import org.json.JSONObject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -113,6 +115,42 @@ class AdyenDropInModule(private val reactContext : ReactApplicationContext): Rea
         Log.e(TAG, err.toString())
         rejectCallback?.invoke("Failed to set module config. Check the config object values and that its types are correct. ${err.message}")
       }
+    }
+  }
+
+  @ReactMethod
+  fun setSubmitCallback(callback: Callback?) {
+    Log.d(TAG, "Called setSubmitCallback")
+    memoryStorage.onSubmitCallback = callback
+  }
+
+  @ReactMethod
+  fun setAdditionalDetailsCallback(callback: Callback?) {
+    Log.d(TAG, "Called setAdditionalDetailsCallback")
+    memoryStorage.onAdditionalDetailsCallback = callback
+  }
+
+  @ReactMethod
+  fun setPaymentResponse(paymentResponse: ReadableMap?) {
+    Log.d(TAG, "Called setPaymentResponse")
+    if (paymentResponse == null) return
+
+    try {
+      AdyenDropInService.handleAsyncResponse(paymentResponse)
+    } catch (err: Exception) {
+      this.handleError(err.message  ?: "Unknown error in setPaymentResponse")
+    }
+  }
+
+  @ReactMethod
+  fun setDetailsResponse(detailsResponse: ReadableMap?) {
+    Log.d(TAG, "Called setDetailsResponse")
+    if (detailsResponse == null) return
+
+    try {
+      AdyenDropInService.handleAsyncResponse(detailsResponse)
+    } catch (err: Exception) {
+      this.handleError(err.message  ?: "Unknown error in setDetailsResponse")
     }
   }
 

--- a/android/src/main/java/com/reactnativeadyendropin/data/storage/MemoryStorage.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/data/storage/MemoryStorage.kt
@@ -1,6 +1,7 @@
 package com.reactnativeadyendropin.data.storage
 
 import com.adyen.checkout.components.model.payments.Amount
+import com.facebook.react.bridge.Callback
 import com.reactnativeadyendropin.data.api.model.paymentsRequest.AdditionalData
 
 class MemoryStorage {
@@ -37,6 +38,8 @@ class MemoryStorage {
   var headers: Map<String, String> = mutableMapOf()
   var makePaymentEndpoint: String = DEFAULT_PAYMENT_ENDPOINT
   var makeDetailsCallEndpoint: String = DEFAULT_DETAILS_ENDPOINT
+  var onSubmitCallback: Callback? = null
+  var onAdditionalDetailsCallback: Callback? = null
 
   fun getAmount(): Amount {
     val amount = Amount()

--- a/android/src/main/java/com/reactnativeadyendropin/service/AdyenDropInService.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/service/AdyenDropInService.kt
@@ -2,9 +2,13 @@ package com.reactnativeadyendropin.service
 
 import android.util.Log
 import com.adyen.checkout.core.model.toStringPretty
+import com.adyen.checkout.components.ActionComponentData
+import com.adyen.checkout.components.PaymentComponentState
 import com.adyen.checkout.dropin.service.DropInService
 import com.adyen.checkout.dropin.service.DropInServiceResult
 import com.adyen.checkout.redirect.RedirectComponent
+import com.facebook.react.bridge.ReadableMap
+import com.reactnativeadyendropin.RNUtils
 import com.reactnativeadyendropin.data.storage.MemoryStorage
 import com.reactnativeadyendropin.repositories.paymentMethods.PaymentsRepository
 import okhttp3.MediaType
@@ -25,10 +29,74 @@ class AdyenDropInService : DropInService() {
   companion object {
     private val TAG = "AdyenDropInService"
     private val CONTENT_TYPE: MediaType = "application/json".toMediaType()
+    private var instance: AdyenDropInService? = null
+
+    fun handleAsyncResponse(response: ReadableMap) {
+      val resultCode = response.getString("resultCode")
+      Log.d(TAG, "handleAsyncResponse - ${resultCode}")
+
+      when (resultCode) {
+        "Authorised",
+        "Pending",
+        "Received",
+        "ChallengeShopper",
+        "IdentifyShopper",
+        "PresentToShopper",
+        "RedirectShopper" -> {
+          val action = response.getMap("action")
+          if (action != null) {
+            instance?.sendResult(DropInServiceResult.Action(JSONObject(action.toHashMap()).toString()))
+          } else {
+            instance?.sendResult(DropInServiceResult.Finished(JSONObject(response.toHashMap()).toString()))
+          }
+        }
+
+        "Cancelled",
+        "Error",
+        "Refused" -> {
+          instance?.sendResult(DropInServiceResult.Error(reason = resultCode))
+        }
+      }
+    }
   }
 
   private val paymentsRepository: PaymentsRepository by inject()
   private val memoryStorage: MemoryStorage by inject()
+
+  init {
+    instance = this
+  }
+
+  override fun onPaymentsCallRequested(paymentComponentState: PaymentComponentState<*>, paymentComponentJson: JSONObject) {
+    Log.d(TAG, "onPaymentsCallRequested")
+
+    if (memoryStorage.onSubmitCallback == null) {
+      super.onPaymentsCallRequested(paymentComponentState, paymentComponentJson)
+      return
+    }
+
+    val event = RNUtils.jsonToWritableMap(paymentComponentJson)
+
+    if (event != null) {
+      event.putString("channel", "Android")
+      memoryStorage.onSubmitCallback?.invoke(event)
+    }
+  }
+
+  override fun onDetailsCallRequested(actionComponentData: ActionComponentData, actionComponentJson: JSONObject) {
+    Log.d(TAG, "onDetailsCallRequested")
+
+    if (memoryStorage.onAdditionalDetailsCallback == null) {
+      super.onDetailsCallRequested(actionComponentData, actionComponentJson)
+      return
+    }
+
+    val event = RNUtils.jsonToWritableMap(actionComponentJson)
+
+    if (event != null) {
+      memoryStorage.onAdditionalDetailsCallback?.invoke(event)
+    }
+  }
 
   override fun makePaymentsCall(paymentComponentJson: JSONObject): DropInServiceResult {
     Log.d(TAG, "makePaymentsCall")

--- a/ios/AdyenDropInModule.m
+++ b/ios/AdyenDropInModule.m
@@ -4,6 +4,10 @@
 
 RCT_EXTERN_METHOD(setDropInConfig: (NSDictionary? *)config)
 RCT_EXTERN_METHOD(setModuleConfig: (NSDictionary? *)config)
+RCT_EXTERN_METHOD(setSubmitCallback: (RCTResponseSenderBlock *)onSubmit)
+RCT_EXTERN_METHOD(setAdditionalDetailsCallback: (RCTResponseSenderBlock *)onAdditionalDetails)
+RCT_EXTERN_METHOD(setPaymentResponse: (NSDictionary? *)paymentResponse)
+RCT_EXTERN_METHOD(setDetailsResponse: (NSDictionary? *)detailsResponse)
 RCT_EXTERN_METHOD(start: (NSDictionary *)paymentMethodsResponse resolveCallback:(RCTResponseSenderBlock *)resolveCallback rejectCallback:(RCTResponseSenderBlock *)rejectCallback)
 
 @end

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,11 @@ export type ModuleConfig = {
      */
     makeDetailsCall: string;
   };
+  /** Optional custom callbacks */
+  callbacks?: {
+    onSubmit: (data: any) => void;
+    onAdditionalDetails: (data: any) => void;
+  };
 };
 
 export type PaymentMethod = {
@@ -188,6 +193,30 @@ const AdyenDropIn = {
   setModuleConfig(moduleConfig: ModuleConfig) {
     const cleanedModuleConfig = cleanModuleConfig(moduleConfig);
     AdyenDropInModule.setModuleConfig(cleanedModuleConfig);
+    if (moduleConfig.callbacks) {
+      AdyenDropInModule.setSubmitCallback(moduleConfig.callbacks.onSubmit);
+      AdyenDropInModule.setAdditionalDetailsCallback(
+        moduleConfig.callbacks.onAdditionalDetails
+      );
+    }
+    return this;
+  },
+  /**
+   * ***Optional*** Call this function to set payment response for the RN module
+   * @param paymentResponse Payment response object
+   * @returns `AdyenDropIn` instance (`this`)
+   */
+  setPaymentResponse(paymentResponse: any) {
+    AdyenDropInModule.setPaymentResponse(paymentResponse);
+    return this;
+  },
+  /**
+   * ***Optional*** Call this function to set details response for the RN module
+   * @param detailsResponse Details response object
+   * @returns `AdyenDropIn` instance (`this`)
+   */
+  setDetailsResponse(detailsResponse: any) {
+    AdyenDropInModule.setDetailsResponse(detailsResponse);
     return this;
   },
   /**


### PR DESCRIPTION
This makes it possible to pass custom payment callbacks from TypeScript.

This was possible before using version 0.5.0 of this module, but the
functionality no longer exists after replacing AdyenDropInView.

We depend on this functionality in our app, so this patch is an effort
to bring it back.