### PR TITLE
feat(android+ios): add queryParameters and disableNativeRequests

### DIFF
--- a/android/src/main/java/com/reactnativeadyendropin/AdyenDropInModule.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/AdyenDropInModule.kt
@@ -100,9 +100,18 @@ class AdyenDropInModule(private val reactContext : ReactApplicationContext): Rea
           }
         }
 
+        if (config.hasKey("disableNativeRequests")) {
+          memoryStorage.disableNativeRequests = config.getBoolean("disableNativeRequests")
+        }
+
         if (config.hasKey("headers")) {
           val map = config.getMap("headers")!!
           memoryStorage.headers = RNUtils.readableMapToStringMap(map)
+        }
+
+        if (config.hasKey("queryParameters")) {
+          val map = config.getMap("queryParameters")!!
+          memoryStorage.queryParameters = RNUtils.readableMapToStringMap(map)
         }
 
         if (config.hasKey("endpoints")) {

--- a/android/src/main/java/com/reactnativeadyendropin/data/api/CheckoutApiService.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/data/api/CheckoutApiService.kt
@@ -3,16 +3,13 @@ package com.reactnativeadyendropin.data.api
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Call
-import retrofit2.http.Body
-import retrofit2.http.HeaderMap
-import retrofit2.http.POST
-import retrofit2.http.Url
+import retrofit2.http.*
 
 interface CheckoutApiService {
   // There is no native support for JSONObject in either Moshi or Gson, so using RequestBody as a work around for now
   @POST()
-  fun payments(@HeaderMap headers: Map<String, String>, @Url makePaymentUrl: String, @Body paymentsRequest: RequestBody): Call<ResponseBody>
+  fun payments(@HeaderMap headers: Map<String, String>, @Url makePaymentUrl: String, @QueryMap queryParameters: Map<String, String>, @Body paymentsRequest: RequestBody): Call<ResponseBody>
 
   @POST()
-  fun details(@HeaderMap headers: Map<String, String>, @Url makeDetailsCallUrl: String, @Body detailsRequest: RequestBody): Call<ResponseBody>
+  fun details(@HeaderMap headers: Map<String, String>, @Url makeDetailsCallUrl: String, @QueryMap queryParameters: Map<String, String>, @Body detailsRequest: RequestBody): Call<ResponseBody>
 }

--- a/android/src/main/java/com/reactnativeadyendropin/data/storage/MemoryStorage.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/data/storage/MemoryStorage.kt
@@ -35,7 +35,9 @@ class MemoryStorage {
   // RN module related
   var baseUrl: String = DEFAULT_BASE_URL
   var debug: Boolean = false
+  var disableNativeRequests: Boolean = false
   var headers: Map<String, String> = mutableMapOf()
+  var queryParameters: Map<String, String> = mutableMapOf()
   var makePaymentEndpoint: String = DEFAULT_PAYMENT_ENDPOINT
   var makeDetailsCallEndpoint: String = DEFAULT_DETAILS_ENDPOINT
   var onSubmitCallback: Callback? = null

--- a/android/src/main/java/com/reactnativeadyendropin/repositories/paymentMethods/PaymentsRepository.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/repositories/paymentMethods/PaymentsRepository.kt
@@ -7,16 +7,16 @@ import okhttp3.ResponseBody
 import retrofit2.Call
 
 interface PaymentsRepository {
-  fun paymentsRequest(headers: Map<String, String>, makePaymentUrl: String, paymentsRequest: RequestBody): Call<ResponseBody>
-  fun detailsRequest(headers: Map<String, String>, makeDetailsCallUrl: String, paymentsRequest: RequestBody): Call<ResponseBody>
+  fun paymentsRequest(headers: Map<String, String>, queryParameters: Map<String, String>, makePaymentUrl: String, paymentsRequest: RequestBody): Call<ResponseBody>
+  fun detailsRequest(headers: Map<String, String>, queryParameters: Map<String, String>, makeDetailsCallUrl: String, paymentsRequest: RequestBody): Call<ResponseBody>
 }
 
 class PaymentsRepositoryImpl(private val checkoutApiService: CheckoutApiService) : PaymentsRepository, BaseRepository() {
-  override fun paymentsRequest(headers: Map<String, String>, makePaymentUrl: String, paymentsRequest: RequestBody): Call<ResponseBody> {
-    return checkoutApiService.payments(headers, makePaymentUrl, paymentsRequest)
+  override fun paymentsRequest(headers: Map<String, String>, queryParameters: Map<String, String>, makePaymentUrl: String, paymentsRequest: RequestBody): Call<ResponseBody> {
+    return checkoutApiService.payments(headers, makePaymentUrl, queryParameters, paymentsRequest)
   }
 
-  override fun detailsRequest(headers: Map<String, String>, makeDetailsCallUrl: String, paymentsRequest: RequestBody): Call<ResponseBody> {
-    return checkoutApiService.details(headers, makeDetailsCallUrl, paymentsRequest)
+  override fun detailsRequest(headers: Map<String, String>, queryParameters: Map<String, String>, makeDetailsCallUrl: String, paymentsRequest: RequestBody): Call<ResponseBody> {
+    return checkoutApiService.details(headers, makeDetailsCallUrl, queryParameters, paymentsRequest)
   }
 }

--- a/android/src/main/java/com/reactnativeadyendropin/service/AdyenDropInService.kt
+++ b/android/src/main/java/com/reactnativeadyendropin/service/AdyenDropInService.kt
@@ -70,8 +70,11 @@ class AdyenDropInService : DropInService() {
   override fun onPaymentsCallRequested(paymentComponentState: PaymentComponentState<*>, paymentComponentJson: JSONObject) {
     Log.d(TAG, "onPaymentsCallRequested")
 
-    if (memoryStorage.onSubmitCallback == null) {
+    if (!memoryStorage.disableNativeRequests) {
       super.onPaymentsCallRequested(paymentComponentState, paymentComponentJson)
+    }
+
+    if (memoryStorage.onSubmitCallback == null) {
       return
     }
 
@@ -86,8 +89,11 @@ class AdyenDropInService : DropInService() {
   override fun onDetailsCallRequested(actionComponentData: ActionComponentData, actionComponentJson: JSONObject) {
     Log.d(TAG, "onDetailsCallRequested")
 
-    if (memoryStorage.onAdditionalDetailsCallback == null) {
+    if (!memoryStorage.disableNativeRequests) {
       super.onDetailsCallRequested(actionComponentData, actionComponentJson)
+    }
+
+    if (memoryStorage.onAdditionalDetailsCallback == null) {
       return
     }
 
@@ -120,6 +126,7 @@ class AdyenDropInService : DropInService() {
 
     val call = paymentsRepository.paymentsRequest(
       memoryStorage.headers,
+      memoryStorage.queryParameters,
       url,
       requestBody
     )
@@ -137,6 +144,7 @@ class AdyenDropInService : DropInService() {
 
     val call = paymentsRepository.detailsRequest(
       memoryStorage.headers,
+      memoryStorage.queryParameters,
       url,
       requestBody
     )

--- a/ios/Configuration/MemoryStorage.swift
+++ b/ios/Configuration/MemoryStorage.swift
@@ -9,7 +9,11 @@ class MemoryStorage {
     
     var debug: Bool = false
     
+    var disableNativeRequests: Bool = false
+    
     var headers: [String: String]? = nil
+    
+    var queryParameters: [URLQueryItem]? = nil
     
     var makePaymentEndpoint: String = "payments"
     

--- a/ios/Networking/PaymentDetailsRequest.swift
+++ b/ios/Networking/PaymentDetailsRequest.swift
@@ -22,9 +22,13 @@ internal struct PaymentDetailsRequest: APIRequest {
     
     internal var headers: [String: String] = [:]
     
-    init(headers: [String: String]?, path: String?, details: AdditionalDetails, paymentData: String?, merchantAccount: String?) {
+    init(headers: [String: String]?, queryParameters: [URLQueryItem]?, path: String?, details: AdditionalDetails, paymentData: String?, merchantAccount: String?) {
         if (headers != nil) {
             self.headers = headers!
+        }
+        
+        if (queryParameters != nil) {
+            self.queryParameters = queryParameters!
         }
         
         if (path != nil) {

--- a/ios/Networking/PaymentsRequest.swift
+++ b/ios/Networking/PaymentsRequest.swift
@@ -20,9 +20,13 @@ internal struct PaymentsRequest: Request {
     
     internal var headers: [String: String] = [:]
     
-    init(headers: [String: String]?, path: String?, data: PaymentComponentData) {
+    init(headers: [String: String]?, queryParameters: [URLQueryItem]?, path: String?, data: PaymentComponentData) {
         if (headers != nil) {
             self.headers = headers!
+        }
+        
+        if (queryParameters != nil) {
+            self.queryParameters = queryParameters!
         }
         
         if (path != nil) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,20 @@ export type ModuleConfig = {
    * Set to `true` to view more native logs
    */
   debug?: boolean;
+  /** Optional Set to `true` to disable native requests.
+   *
+   * Remember to provide custom callbacks and call setPaymentResponse
+   * and setDetailsResponse.
+   *
+   * **Unsafe! The JavaScript thread might get paused on Android!**
+   */
+  disableNativeRequests?: boolean;
   /** Optional custom headers to add to requests */
   headers?: {
+    [key: string]: string;
+  };
+  /** Optional custom query parameters to add to requests */
+  queryParameters?: {
     [key: string]: string;
   };
   /** Optional custom endpoints */


### PR DESCRIPTION
This patch will run native requests regardless of callbacks being set
or not, and adds two new fields in `ModuleConfig`:

* `queryParameters`: Use this to provide custom query parameters for
  native requests.

* `disableNativeRequests`: Set to `true` if you want to disable native
  requests. Remember to provide custom callbacks and call
  `setPaymentResponse` and `setDetailsResponse`. **Unsafe! The JavaScript
  thread might get paused on Android!**