### PR TITLE
fix(ios): don't allow paying twice

### DIFF
--- a/ios/AdyenDropInModule.swift
+++ b/ios/AdyenDropInModule.swift
@@ -369,6 +369,12 @@ extension AdyenDropInModule: DropInComponentDelegate {
     }
 
     internal func didProvide(_ data: ActionComponentData, from component: DropInComponent) {
+        // We need to disable user interaction while processing payments, because otherwise
+        // it might be possible to start another payment while waiting.
+        // Details: https://github.com/Adyen/adyen-ios/issues/714
+        print("Disabling user interaction")
+        currentComponent?.viewController.view.isUserInteractionEnabled = false
+        
         if self.onAdditionalDetailsCallback != nil {
             self.onAdditionalDetailsCallback?([[
                 "details": data.details.dictionary as Any,


### PR DESCRIPTION
Disable user interaction when didProvide() is called to block input
while processing payments from other apps.

Because the Adyen drop-in is still visible after having authorized
payment in an external app (Vipps) and returned back to our app, it
might otherwise be possible to initiate a second payment while the
first is still processing.

Details: https://github.com/Adyen/adyen-ios/issues/714